### PR TITLE
Fix navigation links, spelling errors, and AI attribution format

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - [llama.cpp](https://github.com/ggml-org/llama.cpp) (LLM inference engine mostly targeting CPUs);
 - [GGUF](https://huggingface.co/docs/hub/en/gguf) (binary file format for storing quantized models).
 
-GGUF quantization implements *Post-Training Quantization* (PTQ): given an already-trained Llama-like model in high precision, it reduces the bit width of each individual weight. The resulting checkpoint requires less memory and thus facillitates inference on consumer-grade hardware.
+GGUF quantization implements *Post-Training Quantization* (PTQ): given an already-trained Llama-like model in high precision, it reduces the bit width of each individual weight. The resulting checkpoint requires less memory and thus facilitates inference on consumer-grade hardware.
 
 ## Who built it? Why are there no official docs?
 GGUF was inspired by previous PTQ methods, including [GPTQ](https://arxiv.org/abs/2210.17323), [AWQ](https://arxiv.org/abs/2306.00978), [QLoRA](https://arxiv.org/abs/2305.14314) and [QuIP#](https://arxiv.org/abs/2402.04396). But unlike most prior work that came out of research labs, the GGUF ecosystem was developed by the prolific open-source contributor [Georgi Gerganov](https://github.com/ggerganov) and a few others.

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -45,4 +45,4 @@
 [Placeholder for instructions to reproduce results]
 
 ---
-[← Back: Practical Guide](practical-guide.md) | [Back to Main](README.md)
+[← Back: Commands](commands.md) | [Back to Main](README.md)

--- a/i-quants.md
+++ b/i-quants.md
@@ -20,7 +20,7 @@ In contrast, I-quants treat groups of 8 weights as indivisible. This is *vector*
 w_vec = [w_1, w_2, ..., w_8] → integer_quant
 ```
 
-Vector quantization is facillitated by a *codebook* of *reference* (or *prototype*) vectors, with entries of this form:
+Vector quantization is facilitated by a *codebook* of *reference* (or *prototype*) vectors, with entries of this form:
 ```
 r_vec = [r_1, r_2, ..., r_8] → integer_code
 ```

--- a/importance-matrix.md
+++ b/importance-matrix.md
@@ -14,7 +14,7 @@ For a weight matrix `W`, the importance matrix `I` has the same dimensions as `W
 <img src="images/importance-matrix.png" alt="importance-matrix" style="max-height: 400px;">
 
 ### The calibration set
-Since the definition of weight importance is tied to model behavior ("important weights cause big changes in model output"), we need to watch the model behavior on a *calibration set*. It's typical to use a few hundred instances from [Wikitext](https://huggingface.co/datasets/Salesforce/wikitext), a subsest of Wikipedia. There have been some discussions about [overfitting](https://www.reddit.com/r/LocalLLaMA/comments/1993iro/ggufs_quants_can_punch_above_their_weights_now/), though the authors claim overfitting is unlikely (see [comment](https://github.com/ggml-org/llama.cpp/discussions/5006#discussioncomment-8166807)).
+Since the definition of weight importance is tied to model behavior ("important weights cause big changes in model output"), we need to watch the model behavior on a *calibration set*. It's typical to use a few hundred instances from [Wikitext](https://huggingface.co/datasets/Salesforce/wikitext), a subset of Wikipedia. There have been some discussions about [overfitting](https://www.reddit.com/r/LocalLLaMA/comments/1993iro/ggufs_quants_can_punch_above_their_weights_now/), though the authors claim overfitting is unlikely (see [comment](https://github.com/ggml-org/llama.cpp/discussions/5006#discussioncomment-8166807)).
 
 Given a calibration dataset, the importance matrix is calculated based on the *activation* values, an idea borrowed from the [AWQ](https://arxiv.org/abs/2306.00978) paper.
 
@@ -66,12 +66,12 @@ To squeeze the last bit of performance, GGUF does a small grid search around the
 <img src="images/imatrix-code.png" alt="imatrix-code" style="max-height: 400px;">
 
 ## What overhead does the importance marix incur?
-None during inference! The importance matrix simply leads to more strategic choices of quantization constants. By inspecting a quantized checkpoint, there's virtually no way to tell whether the imporance matrix was used, since it doesn't store any extra values. (This is frustrating for some people, since they can't trace back how a checkpoint was quantized).
+None during inference! The importance matrix simply leads to more strategic choices of quantization constants. By inspecting a quantized checkpoint, there's virtually no way to tell whether the importance matrix was used, since it doesn't store any extra values. (This is frustrating for some people, since they can't trace back how a checkpoint was quantized).
 
 There's just a bit more pre-processing work to (a) pick a calibration dataset, (b) compute the imatrix, and (c) pass it to the quantization binary.
 
 ## Performance Impact
-⚠️ Section written by Claude Code, proceed with caution.
+⚠️🤖
 
 ### Quality Improvements
 - **Significant gains**: 10-30% perplexity improvement common with importance matrix
@@ -89,7 +89,7 @@ There's just a bit more pre-processing work to (a) pick a calibration dataset, (
 - **Inference**: No additional memory overhead
 
 ## Best Practices
-⚠️ Section written by Claude Code, proceed with caution.
+⚠️🤖
 
 ### Calibration Dataset Selection
 - **Use representative data**: Match your intended use case as closely as possible
@@ -114,4 +114,4 @@ There's just a bit more pre-processing work to (a) pick a calibration dataset, (
 - **Simple deployments**: May not justify additional complexity for some use cases
 
 ---
-[← Back: I-Quants](i-quants.md) | [Next: Practical Guide →](practical-guide.md)
+[← Back: I-Quants](i-quants.md) | [Next: Naming →](naming.md)

--- a/naming.md
+++ b/naming.md
@@ -49,4 +49,4 @@ For instance, the screenshot below compares `Q4_K_S` (left) against `Q4_K_M` (ri
 
 
 ---
-[← Back to Main](README.md)
+[← Back to Main](README.md) | [Next: Commands →](commands.md)


### PR DESCRIPTION
## Summary

While reviewing the documentation, I noticed several issues that affect navigation and readability:

1. **Broken navigation links** - Multiple files referenced a non-existent `practical-guide.md`, breaking the sequential reading flow
2. **Incomplete navigation** - The naming.md page lacked forward navigation, creating a dead end
3. **Spelling errors** - Found 4 typos across the documentation
4. **Inconsistent AI attribution** - The importance-matrix.md file used a different format than specified in the README

## Here are the Changes I Made

### Nav Fixes
- **importance-matrix.md**: Changed link from `practical-guide.md` to `naming.md` (correct next page)
- **benchmarks.md**: Changed link from `practical-guide.md` to `commands.md` (correct previous page)
- **naming.md**: Added forward navigation to `commands.md` to complete the documentation chain

### Spelling Corrections
- **README.md**: `facillitates` → `facilitates`
- **i-quants.md**: `facillitated` → `facilitated`
- **importance-matrix.md**: `subsest` → `subset`
- **importance-matrix.md**: `imporance` → `importance`

### Format Standardization
- **importance-matrix.md**: Updated AI attribution from verbose text to ⚠️🤖 format (2 instances) to match README standard! :) I like this concept BTW.

## Testing

- I verified all navigation links now point to existing files
- Confirmed sequential reading path works correctly: README → Legacy Quants → K-Quants → I-Quants → Importance Matrix → Naming → Commands → Benchmarks
- All spelling corrections verified in context
- AI attribution now consistent with README specification

No functional changes to code or algorithms, that all works great - purely documentation improvements.